### PR TITLE
Update README.md to warn users to install curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This software is available under the [GNU General Public License](http://www.gnu
 __Please use a different name and logo if you run it on a public server.__
 
 ##Other dependencies
-You need [avconv](https://libav.org/avconv.html), [rtmpdump](http://rtmpdump.mplayerhq.hu/) and curl (https://curl.haxx.se/) in order to enable conversions.
+You need [avconv](https://libav.org/avconv.html), [rtmpdump](http://rtmpdump.mplayerhq.hu/) and [curl](https://curl.haxx.se/) in order to enable conversions.
 If you don't want to enable conversions, you can disable it in *config.yml*.
 
 On Debian-based systems:

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ This software is available under the [GNU General Public License](http://www.gnu
 __Please use a different name and logo if you run it on a public server.__
 
 ##Other dependencies
-You need [avconv](https://libav.org/avconv.html) and [rtmpdump](http://rtmpdump.mplayerhq.hu/) in order to enable conversions.
+You need [avconv](https://libav.org/avconv.html), [rtmpdump](http://rtmpdump.mplayerhq.hu/) and curl (https://curl.haxx.se/) in order to enable conversions.
 If you don't want to enable conversions, you can disable it in *config.yml*.
 
 On Debian-based systems:
 
-    sudo apt-get install libav-tools rtmpdump
+    sudo apt-get install libav-tools rtmpdump curl
 
 You also probably need to edit the *avconv* variable in *config.yml* so that it points to your ffmpeg/avconv binary (*/usr/bin/avconv* on Debian/Ubuntu).


### PR DESCRIPTION
If users download the release version of Alltube (don't build it themselves using npm/composer) AND if they do not have curl installed on their ubuntu system (happened to me, uninstalled it for testing purposes), mp3 files of 0 bytes will be served by alltube after conversion. Curl is needed to transfer the mp3 files.