### PR TITLE
Fix double slashes on canonical url

### DIFF
--- a/controllers/FrontController.php
+++ b/controllers/FrontController.php
@@ -558,7 +558,7 @@ class FrontController
     private function getCanonicalUrl(Request $request)
     {
         $uri = $request->getUri();
-        $return = 'https://alltubedownload.net/';
+        $return = 'https://alltubedownload.net';
 
         $path = $uri->getPath();
         if ($path != '/') {


### PR DESCRIPTION
This fix double slashes on canonical meta tag ex: **<link rel="canonical" href="https://alltubedownload.net//extractors" />**