### PR TITLE
fixed ffmpeg binary download url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "name": "ffmpeg/ffmpeg",
         "version": "4.0.2",
         "dist": {
-          "url": "https://johnvansickle.com/ffmpeg/releases/ffmpeg-4.0.2-64bit-static.tar.xz",
+          "url": "https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz",
           "type": "xz"
         },
         "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -1451,7 +1451,7 @@
             "version": "4.0.2",
             "dist": {
                 "type": "xz",
-                "url": "https://johnvansickle.com/ffmpeg/releases/ffmpeg-4.0.2-64bit-static.tar.xz",
+                "url": "https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.0.3-64bit-static.tar.xz",
                 "reference": null,
                 "shasum": null
             },


### PR DESCRIPTION
The URL provided in composer files are wrong and lead to 404s. I linked to the next highest version that is still available