### PR TITLE
Add missing closing double-quote in filename header for remuxes

### DIFF
--- a/controllers/DownloadController.php
+++ b/controllers/DownloadController.php
@@ -222,7 +222,7 @@ class DownloadController extends BaseController
 
         return $response->withHeader(
             'Content-Disposition',
-            'attachment; filename="' . $this->video->getFileNameWithExtension('mkv')
+            'attachment; filename="' . $this->video->getFileNameWithExtension('mkv') . '"'
         );
     }
 


### PR DESCRIPTION
It's funny that Firefox was tolerating this but not Safari iOS.