### PR TITLE
Fix xHamster support, fixes #264

### DIFF
--- a/classes/Video.php
+++ b/classes/Video.php
@@ -615,7 +615,7 @@ class Video
         $urls = $this->getUrl();
         $stream_context_options = [];
 
-        if (array_key_exists('Referer', $this->http_headers)) {
+        if (array_key_exists('Referer', (array)$this->http_headers)) {
             $stream_context_options = [
                 'http' => [
                     'header' => 'Referer: ' . $this->http_headers->Referer
@@ -629,7 +629,7 @@ class Video
             [
                 'stream' => true,
                 'stream_context' => $stream_context_options,
-                'headers' => array_merge((array) $this->http_headers, $headers)
+                'headers' => array_merge((array)$this->http_headers, $headers)
             ]
         );
     }

--- a/classes/Video.php
+++ b/classes/Video.php
@@ -618,7 +618,7 @@ class Video
         if (array_key_exists('Referer', $this->http_headers)) {
             $stream_context_options = [
                 'http' => [
-                    'header' => 'Referer: '.$this->http_headers->Referer
+                    'header' => 'Referer: ' . $this->http_headers->Referer
                 ]
             ];
         }

--- a/classes/Video.php
+++ b/classes/Video.php
@@ -615,10 +615,10 @@ class Video
         $urls = $this->getUrl();
         $stream_context_options = [];
 
-        if (strpos($this->webpageUrl, 'xhamster.com') !== false) {
+        if (array_key_exists('Referer', $this->http_headers)) {
             $stream_context_options = [
                 'http' => [
-                    'header' => 'Referer: https://xhamster.com'
+                    'header' => 'Referer: '.$this->http_headers->Referer
                 ]
             ];
         }

--- a/classes/Video.php
+++ b/classes/Video.php
@@ -613,12 +613,22 @@ class Video
     {
         $client = new Client();
         $urls = $this->getUrl();
+        $stream_context_options = [];
+
+        if (strpos($this->webpageUrl, 'xhamster.com') !== false) {
+            $stream_context_options = [
+                'http' => [
+                    'header' => 'Referer: https://xhamster.com'
+                ]
+            ];
+        }
 
         return $client->request(
             'GET',
             $urls[0],
             [
                 'stream' => true,
+                'stream_context' => $stream_context_options,
                 'headers' => array_merge((array) $this->http_headers, $headers)
             ]
         );


### PR DESCRIPTION
As described in #264 xHamster downloads are not possible, unless their site itself is specified as HTTP-Referer.
Since it didn't work for me either, I tried to fix it.
As it seems, it only works if the referer is passed as custom stream context option, as this overrides other values. 

further details here:
<http://docs.guzzlephp.org/en/stable/faq.html#how-can-i-add-custom-stream-context-options>
<https://www.php.net/manual/en/context.http.php#context.http.header>

Setting the referer as Guzzle request header (<http://docs.guzzlephp.org/en/stable/request-options.html#headers>) or through CURLOPT_REFERER did not work.

With this fix, it's possible to download videos from xHamster if the stream option is activated.
To achieve this without the streaming option, I recommend to use a plugin in your web browser.