### PR TITLE
heroku hot-fix for docker deploying

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+a2dismod mpm_event &&
+sed -i "s/Listen 80/Listen ${PORT:-80}/g" /etc/apache2/ports.conf
+apache2-foreground "$@"


### PR DESCRIPTION
Fixed `apache2: Configuration error: More than one MPM loaded` and `Permission denied: AH00072: make_sock: could not bind to address [::]:80`

now the code will work fine