### PR TITLE
Fix dockerfile templates_c/ permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ COPY resources/php.ini /usr/local/etc/php/
 COPY . /var/www/html/
 RUN php composer.phar check-platform-reqs --no-dev
 RUN php composer.phar install --prefer-dist --no-progress --no-dev --optimize-autoloader
+RUN chmod 770 -R /var/www/html/templates_c/
 ENV CONVERT=1


### PR DESCRIPTION
Fix the error with permission issue in /var/www/html/templates_c/ folder when building docker image